### PR TITLE
Change Readme to Yii3 extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
     <a href="https://github.com/yiisoft" target="_blank">
         <img src="https://avatars0.githubusercontent.com/u/6154722" height="100px">
     </a>
-    <h1 align="center">MSSQL Server Extension for Yii 2</h1>
+    <h1 align="center">MSSQL Server Extension for Yii 3</h1>
     <br>
 </p>
 
-This extension provides the MSSQL Server support for the [Yii framework 2.1](http://www.yiiframework.com).
+This extension provides the MSSQL Server support for the [Yii framework 3 ](http://www.yiiframework.com) (formerly Yii 2.1).
 
 For license information check the [LICENSE](LICENSE.md)-file.
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,7 +1,7 @@
-REST Extension for Yii 2
+MSSQL Server Extension for Yii 3
 ========================
 
-This extension provides the MSSQL Server support for the [Yii framework 2.1](http://www.yiiframework.com).
+This extension provides the MSSQL Server support for the [Yii framework 3](http://www.yiiframework.com).
 
 Getting Started
 ---------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

This extension give confusion to Yii2 user (especially new Yii2 user) since it readme state this extension as Yii2 extension.