### PR TITLE
bug #8 - solution for correct getting PK from insert query without function `getLastInsertID`

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -955,6 +955,9 @@ SQL;
              */
             if (isset($inserted[$name])) {
                 $result[$name] = $inserted[$name];
+            } elseif ($tableSchema->getColumns()[$name]->isAutoIncrement()) {
+                // for a version earlier than 2005
+                $result[$name] = $this->getLastInsertID($tableSchema->getSequenceName());
             } elseif (isset($columns[$name])) {
                 $result[$name] = $columns[$name];
             } else {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -950,10 +950,6 @@ SQL;
 
         $result = [];
         foreach ($tableSchema->getPrimaryKey() as $name) {
-            if ($tableSchema->getColumns()[$name]->isAutoIncrement()) {
-                $result[$name] = $this->getLastInsertID($tableSchema->getSequenceName());
-                break;
-            }
             /**
              * {@see https://github.com/yiisoft/yii2/issues/13828 & https://github.com/yiisoft/yii2/issues/17474
              */

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Mssql\Tests;
 
 use PDO;
+use Yiisoft\Db\Mssql\Schema;
 use function strpos;
 use Yiisoft\Db\Constraint\DefaultValueConstraint;
 use Yiisoft\Db\Mssql\TableSchema;
@@ -502,5 +503,24 @@ final class SchemaTest extends TestCase
         $this->assertInstanceOf(TableSchema::class, $testRefreshedTable);
         $this->assertEquals($refreshedTable, $testRefreshedTable);
         $this->assertNotSame($testNoCacheTable, $testRefreshedTable);
+    }
+
+    public function testGetPrimaryKey(): void
+    {
+        $db = $this->getConnection();
+
+        if ($db->getSchema()->getTableSchema('testPKTable') !== null) {
+            $db->createCommand()->dropTable('testPKTable')->execute();
+        }
+
+        $db->createCommand()->createTable(
+            'testPKTable',
+            ['id' => Schema::TYPE_PK, 'bar' => Schema::TYPE_INTEGER]
+        )->execute();
+
+        $insertResult = $db->getSchema()->insert('testPKTable', ['bar' => 1]);
+        $selectResult = $db->createCommand('select [id] from [testPKTable] where [bar]=1')->queryOne();
+
+        $this->assertEquals($selectResult['id'], $insertResult['id']);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #8 
