### PR TITLE
Implement `getName()` to `ConnectionInterface::class`.

### DIFF
--- a/src/ConnectionPDO.php
+++ b/src/ConnectionPDO.php
@@ -65,6 +65,11 @@ final class ConnectionPDO extends AbstractConnectionPDO
         return $this->queryBuilder;
     }
 
+    public function getName(): string
+    {
+        return $this->getDriver()->getName();
+    }
+
     public function getQuoter(): QuoterInterface
     {
         if ($this->quoter === null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
