### PR TITLE
Better naming `getDriverName()`.

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -25,16 +25,6 @@ final class ConnectionTest extends CommonConnectionTest
 
     /**
      * @throws Exception
-     */
-    public function testGetName(): void
-    {
-        $db = $this->getConnection();
-
-        $this->assertEquals('sqlsrv', $db->getName());
-    }
-
-    /**
-     * @throws Exception
      * @throws InvalidConfigException
      * @throws NotSupportedException
      * @throws Throwable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
