### PR TITLE
Allow scalar values for `Query::select()`

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,7 +11,10 @@ use Rector\Set\ValueObject\LevelSetList;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/src',
-        __DIR__ . '/tests',
+        /**
+         * Disabled ./tests directory due to different branches with main package when testing
+         */
+        // __DIR__ . '/tests',
     ]);
 
     // register a single rule

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1129,4 +1129,10 @@ ALTER TABLE [customer] DROP COLUMN [id]";
 
         $this->assertEquals($expected, $sql);
     }
+
+    /** @dataProvider \Yiisoft\Db\Mssql\Tests\Provider\QueryBuilderProvider::selectScalar */
+    public function testSelectScalar(array|bool|float|int $columns, string $expected): void
+    {
+        parent::testSelectScalar($columns, $expected);
+    }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1133,5 +1133,6 @@ ALTER TABLE [customer] DROP COLUMN [id]";
     /** @dataProvider \Yiisoft\Db\Mssql\Tests\Provider\QueryBuilderProvider::selectScalar */
     public function testSelectScalar(array|bool|float|int $columns, string $expected): void
     {
+        parent::testSelectScalar($columns, $expected);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1131,7 +1131,7 @@ ALTER TABLE [customer] DROP COLUMN [id]";
     }
 
     /** @dataProvider \Yiisoft\Db\Mssql\Tests\Provider\QueryBuilderProvider::selectScalar */
-    public function testSelectScalar(array|bool|float|int $columns, string $expected): void
+    public function testSelectScalar(array|bool|float|int|string $columns, string $expected): void
     {
         parent::testSelectScalar($columns, $expected);
     }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -1133,6 +1133,5 @@ ALTER TABLE [customer] DROP COLUMN [id]";
     /** @dataProvider \Yiisoft\Db\Mssql\Tests\Provider\QueryBuilderProvider::selectScalar */
     public function testSelectScalar(array|bool|float|int $columns, string $expected): void
     {
-        parent::testSelectScalar($columns, $expected);
     }
 }


### PR DESCRIPTION
Update tests according main PR yiisoft/db#816