### PR TITLE
Add `$ifExists` and `$cascade` to `dropTable()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - New #339: Add `IndexType` and `IndexMethod` classes (@Tigrov)
 - Bug #343: Explicitly mark nullable parameters (@vjik)
 - New #342: Support JSON type (@Tigrov)
+- New #345: Add parameters `$ifExists` and `$cascade` to `CommandInterface::dropTable()` and
+  `DDLQueryBuilderInterface::dropTable()` methods (@vjik)
 
 ## 1.2.0 March 21, 2024
 

--- a/src/DDLQueryBuilder.php
+++ b/src/DDLQueryBuilder.php
@@ -314,4 +314,15 @@ WHILE 1=1 BEGIN
     EXEC (N'ALTER TABLE ' + @tableName + ' DROP CONSTRAINT [' + @constraintName + ']')
 END";
     }
+
+    /**
+     * @throws NotSupportedException MSSQL doesn't support cascade drop table.
+     */
+    public function dropTable(string $table, bool $ifExists = false, bool $cascade = false): string
+    {
+        if ($cascade) {
+            throw new NotSupportedException('MSSQL doesn\'t support cascade drop table.');
+        }
+        return parent::dropTable($table, $ifExists, false);
+    }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -311,6 +311,15 @@ final class CommandTest extends CommonCommandTest
         );
     }
 
+    public function testDropTableCascade(): void
+    {
+        $command = $this->getConnection()->createCommand();
+
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessage('MSSQL doesn\'t support cascade drop table.');
+        $command->dropTable('{{table}}', cascade: true);
+    }
+
     public function testShowDatabases(): void
     {
         $expectedDatabases = [];

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Mssql\Tests;
 
 use JsonException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use Throwable;
 use Yiisoft\Db\Exception\Exception;
@@ -951,5 +952,24 @@ ALTER TABLE [customer] DROP COLUMN [id]";
     public function testPrepareValue(string $expected, mixed $value): void
     {
         parent::testPrepareValue($expected, $value);
+    }
+
+    #[DataProvider('dataDropTable')]
+    public function testDropTable(string $expected, ?bool $ifExists, ?bool $cascade): void
+    {
+        if ($cascade) {
+            $qb = $this->getConnection()->getQueryBuilder();
+
+            $this->expectException(NotSupportedException::class);
+            $this->expectExceptionMessage('MSSQL doesn\'t support cascade drop table.');
+
+            $ifExists === null
+                ? $qb->dropTable('customer', cascade: true)
+                : $qb->dropTable('customer', ifExists: $ifExists, cascade: true);
+
+            return;
+        }
+
+        parent::testDropTable($expected, $ifExists, $cascade);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

See https://github.com/yiisoft/db/pull/880